### PR TITLE
Type checking during AST generation without symbol checks (literals and expressions only)

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -25,15 +25,15 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build # -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build # --config ${{env.BUILD_TYPE}}
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest #-C ${{env.BUILD_TYPE}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(mjavac)
 
-find_package(BISON)
-find_package(FLEX)
+find_package(BISON 3.8.2)
+find_package(FLEX 2.6.4)
 
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g --std=c++11")
 set(AUTOGEN_FLEXBISON "${CMAKE_CURRENT_BINARY_DIR}/parse")

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Error Output:
 [1]    61376 abort      ./build/mjavac -p test/TypeError/simpleCheck.java
 ```
 ```
-./build/meval: Type Violation in Line 27
-./build/meval: test/Interpreter/loopCheck.java:27
-./build/meval:             multiplier = multiplier + 1;
+./build/mjavac: Type Violation in Line at token: ")" with while conditional, lineno:25
+./build/mjavac: test/TypeError/loopCheck.java:25
+./build/mjavac:         while (multiplier + 10) {
+[1]    4590 abort      ./build/mjavac -p test/TypeError/loopCheck.java
 ```
 
 ## Build (MacOs)

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Error Output:
 ./build/mjavac:                 int a;
 ```
 ```
-./build/meval: Type Violation in Line 6
-./build/meval: test/Interpreter/simpleCheck.java:6
-./build/meval:         if (true + (2 < 3)) {
+./build/mjavac: Type Violation in Line at token: "true" with expr "+", lineno:6
+./build/mjavac: test/TypeError/simpleCheck.java:6
+./build/mjavac:         if (true + (2 < 3)) {
+[1]    61376 abort      ./build/mjavac -p test/TypeError/simpleCheck.java
 ```
 ```
 ./build/meval: Type Violation in Line 27

--- a/include/TreeNode.hpp
+++ b/include/TreeNode.hpp
@@ -176,9 +176,11 @@ class ClassDeclList : public TreeNode {
 /* Abstract class ClassDecl Start */
 class ClassDecl : public TreeNode {
 	public:
+		Ident * i = nullptr;
 		VarDeclList * v = nullptr;
 		MethodDeclList * m = nullptr;
-		ClassDecl (VarDeclList * v,  MethodDeclList * m) : v(v), m(m) {}
+		ClassDecl (Ident * i, VarDeclList * v,  MethodDeclList * m)
+			: i(i), v(v), m(m) {}
 #ifdef ASSEM
 		virtual void assem() = 0;
 #else 
@@ -191,10 +193,8 @@ class ClassDecl : public TreeNode {
 };
 class ClassDeclSimple : public ClassDecl {
 	public:
-		Ident * i = nullptr;
-
 		ClassDeclSimple (Ident * i, VarDeclList * v,  MethodDeclList * m)
-			: ClassDecl(v, m), i(i) { 
+			: ClassDecl(i, v, m) { 
 #ifdef ASSEM
 			nameTable = new map<string, string*>;
 			typeTable = new map<string, string*>;
@@ -211,9 +211,9 @@ class ClassDeclSimple : public ClassDecl {
 };
 class ClassDeclExtends : public ClassDecl {
 	public:
-		Ident * i1 = nullptr; Ident * i2 = nullptr;
+		Ident * i2 = nullptr;
 		ClassDeclExtends (Ident * i1, Ident * i2, VarDeclList * v,  MethodDeclList * m) 
-			: ClassDecl(v, m), i1(i1), i2(i2) {}
+			: ClassDecl(i1, v, m), i2(i2) {}
 		void traverse();
 #ifdef ASSEM
 		virtual void assem();

--- a/include/TreeNode.hpp
+++ b/include/TreeNode.hpp
@@ -1036,9 +1036,7 @@ class Object : public TreeNode {
 class IdObj : public Object {
 	public: // For: id
 		Ident * i = nullptr;
-		IdObj(Ident * i) : i(i) {
-			// TYPECHECK table lookup for redundancy 
-		}
+		IdObj(Ident * i) : i(i) {}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);

--- a/include/TreeNode.hpp
+++ b/include/TreeNode.hpp
@@ -575,7 +575,11 @@ class ReturnStatement : public Statement {
 	// For: return e 
 	public:
 		Exp * e = nullptr;
-		ReturnStatement(Exp * e) : e(e) {}
+		ReturnStatement(Exp * e) : e(e) {
+			// TYPECHECK:ss
+			// check the type and expr match with table lookup
+			// main is return type void 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);
@@ -674,11 +678,6 @@ class IntResExp : public BinExp {
 	public:
 		IntResExp(Exp * e1, Exp * e2, char tok)
 			: BinExp(e1, e2) {
-				// (TYPECHECK:ss)
-				// if not integer literal or intres expr or id with type int type error
-				// if ObjectMethodCall check e type
-				// if ExpObject fixme 
-				// check they type of the expr within the parentheses
 				if (!e1->isIntRes()) {
 					e1->reportError(" at token: \"" + e1->token + "\" with expr \"" + tok + "\"");
 				}
@@ -863,9 +862,9 @@ class Multiply : public IntResExp {
 class Not : public UnaryExp {
 	public:
 		Not(Exp * e) : UnaryExp(e) {
-			// (TYPECHECK:ss)
-			// if not boolean literal or bool res expr or id with type bool return 
-			// also check the contents of a paren expr
+			if (!e->isBoolRes()) { 
+				e->reportError(" at token: \"" + e->token + "\" with expr \"!\"");
+			}
 		}
 		void traverse();
 #ifdef ASSEM
@@ -877,9 +876,9 @@ class Not : public UnaryExp {
 class Pos : public UnaryExp {
 	public:
 		Pos(Exp * e) : UnaryExp(e) {
-				// (TYPECHECK:ss)
-				// if not integer literal or intres expr or id with type int type error
-				// check the contents of a paren expr 
+			if (!e->isIntRes()) { 
+				e->reportError(" at token: \"" + e->token + "\" with expr \"+\"");
+			}
 		}
 		void traverse();
 #ifdef ASSEM
@@ -891,9 +890,9 @@ class Pos : public UnaryExp {
 class Neg : public UnaryExp {
 	public: 
 		Neg(Exp * e) : UnaryExp(e) {
-				// (TYPECHECK:ss)
-				// if not integer literal or intres expr or id with type int type error
-				// check the contents of a paren expr 
+			if (!e->isIntRes()) { 
+				e->reportError(" at token: \"" + e->token + "\" with expr \"-\"");
+			}
 		}
 		void traverse();
 #ifdef ASSEM
@@ -920,7 +919,7 @@ class ArrayAccess : public Exp {
 		ArrayAccess(Ident * i, Index * ind) : i(i), ind(ind){
 			// (TYPECHECK:ss)
 			// if not integer literal or intres expr or id with type int type error
-			// also check the contents of a paren expr
+			// check if the array is initialized
 		}
 		void traverse();
 #ifdef ASSEM
@@ -935,7 +934,7 @@ class Length : public Exp {
 		Length(Ident * i) : i(i) {
 			// (TYPECHECK:ss)
 			// Check if the id is an array expr
-			// also check the contents of a paren expr
+			// check if the array is initialized
 		}
 		void traverse();
 #ifdef ASSEM
@@ -951,7 +950,7 @@ class ArrayAccessLength : public Exp {
 		ArrayAccessLength(Ident * i, Index * ind) : i(i), ind(ind) {
 			// (TYPECHECK:ss)
 			// Check if the id is an array expr
-			// also check the contents of a paren expr
+			// check if the array is initialized
 		}
 		void traverse();
 #ifdef ASSEM
@@ -995,7 +994,9 @@ class False : public Exp {
 class ExpObject : public Exp {
 	public:
 		Object * o = nullptr;
-		ExpObject(Object * o) : o(o) {}
+		ExpObject(Object * o) : o(o) {
+			// TYPECHECK table lookup for redundancy 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);
@@ -1009,7 +1010,9 @@ class ObjectMethodCall : public Exp {
 		Object * o = nullptr;
 		Ident * i = nullptr;
 		ExpList * e = nullptr;
-		ObjectMethodCall(Object * o, Ident * i, ExpList * e) : o(o), i(i), e(e) {}
+		ObjectMethodCall(Object * o, Ident * i, ExpList * e) : o(o), i(i), e(e) {
+			// TYPECHECK table lookup for exp type 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);
@@ -1033,7 +1036,9 @@ class Object : public TreeNode {
 class IdObj : public Object {
 	public: // For: id
 		Ident * i = nullptr;
-		IdObj(Ident * i) : i(i) {}
+		IdObj(Ident * i) : i(i) {
+			// TYPECHECK table lookup for redundancy 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);
@@ -1053,7 +1058,9 @@ class ThisObj : public Object {
 class NewIdObj : public Object {
 	public: // For: new id ()
 		Ident * i = nullptr;
-		NewIdObj(Ident * i) : i(i) {}
+		NewIdObj(Ident * i) : i(i) {
+			// TYPECHECK table lookup for redundancy 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);
@@ -1065,7 +1072,9 @@ class NewTypeObj : public Object {
 	public:
 		PrimeType * p = nullptr;
 		Index * i = nullptr;
-		NewTypeObj(PrimeType * p, Index * i) : p(p), i(i) {}
+		NewTypeObj(PrimeType * p, Index * i) : p(p), i(i) {
+			// TYPECHECK table lookup for redundancy 
+		}
 		void traverse();
 #ifdef ASSEM
 		void setTable(TableNode * t);

--- a/source/EvalNode.cpp
+++ b/source/EvalNode.cpp
@@ -156,9 +156,7 @@ void Assign::evaluate() {
 	} else if (programRoot->call_stack.back()->find(*i->id) != programRoot->call_stack.back()->end()) {
 		(*programRoot->call_stack.back())[*i->id].val = (e->evaluate());
 	} else {
-		error_msg = "Assign::evaluate() runtime error";
-		error_msg += " token \"" + *i->id + "\"";
-		reportError();
+		reportError(" token \"" + *i->id + "\"", "Assign::evaluate() runtime error");
 	}
 }
 
@@ -169,8 +167,7 @@ void IndexAssign::evaluate() {
 	} else if (programRoot->call_stack.back()->end() != programRoot->call_stack.back()->find(*i->id)) {
 		array = (*programRoot->call_stack.back())[*i->id].val.exp_single;
 	} else {
-		error_msg = "IndexAssign::evaluate() runtime error";
-		reportError();
+		reportError("", "IndexAssign::evaluate() runtime error");
 	}
 	if (dynamic_cast<SingleIndex *>(ind)) {
 		int offset = ind->evaluate();
@@ -303,8 +300,7 @@ VAL ArrayAccess::evaluate() {
 	} else if (programRoot->call_stack.back()->find(*i->id) != programRoot->call_stack.back()->end()) {
 			array = (*programRoot->call_stack.back())[*i->id].val.exp_single;
 	} else {
-		error_msg = "Calling ArrayAccess on uninit array";
-		reportError();
+		reportError("", "Calling ArrayAccess on uninit array");
 	}
 	if (SingleIndex * s_i = dynamic_cast<SingleIndex * >(ind)) {
 		return VAL{array[s_i->e->evaluate().exp + 2]};
@@ -331,14 +327,12 @@ VAL Length::evaluate() {
 	} else if (programRoot->call_stack.back()->find(*i->id) != programRoot->call_stack.back()->end()) {
 			array = (*programRoot->call_stack.back())[*i->id].val.exp_single;
 	} else {
-		error_msg = "Calling ArrayAccess on uninit array";
-		reportError();
+		reportError("", "Calling ArrayAccess on uninit array");
 	}
 
 	if (array == nullptr) {
 		cerr << *i->id << " Calling Length on uninit array " << (*programRoot->scope_stack.back())[*i->id].val.exp_single << endl;
-		error_msg = "Calling ArrayAccess on uninit array";
-		reportError();
+		reportError("", "Calling ArrayAccess on uninit array");
 		return {0};
 	}
 	return {array[1]};
@@ -352,8 +346,7 @@ VAL ArrayAccessLength::evaluate() {
 	} else if (programRoot->call_stack.back()->find(*i->id) != programRoot->call_stack.back()->end()) {
 			array = (*programRoot->call_stack.back())[*i->id].val.exp_single;
 	} else {
-		error_msg = "Calling ArrayAccess on uninit array";
-		reportError();
+		reportError("", "Calling ArrayAccess on uninit array");
 	}
 
   // Index Count len1, l1n2, len3, ... elemen[0][0][0]
@@ -386,16 +379,12 @@ VAL ExpObject::evaluate() {
 		} else if (programRoot->call_stack.back()->find(*_id) != programRoot->call_stack.back()->end()) {
 			return (*programRoot->call_stack.back())[*_id].val;
 		} else {
-			error_msg = "ExpObject::evaluate() runtime error with id: ";
-			error_msg += *_id;
-			reportError();
+			reportError(*_id, "ExpObject::evaluate() runtime error with id: ");
 		}
 	} else if (dynamic_cast<NewIdObj *>(o)) {
-		error_msg = "Err: Trying to evaluate and obj with NewIdObj\n";
-		reportError();
+		reportError("", "Err: Trying to evaluate and obj with NewIdObj\n");
 	} else if (dynamic_cast<ThisObj *>(o)) {
-		error_msg = "Err: Trying to evaluate and obj with ThisObj\n";
-		reportError();
+		reportError("", "Err: Trying to evaluate and obj with ThisObj\n");
 	} else if (NewTypeObj * nto = dynamic_cast<NewTypeObj *>(o)) {
 		// NEW prime_type index 
 		// (Array)

--- a/source/EvalNode.cpp
+++ b/source/EvalNode.cpp
@@ -10,7 +10,7 @@
 
 #include "TreeNode.hpp"
 
-// TODO(ss): Move Type checking within this file during interpretation
+// TODO(ss): Type check during AST generation 
 
 using namespace std;
 
@@ -376,6 +376,8 @@ VAL False::evaluate() {
 	return {0};
 }
 
+// (TYPECHECK:ss)
+// Typecheck objects at evaluation time
 VAL ExpObject::evaluate() {
 	if (IdObj * id = dynamic_cast<IdObj *>(o)) {
 		string * _id = id->i->id;
@@ -431,6 +433,8 @@ VAL ExpObject::evaluate() {
 	return {11};
 }
 
+// (TYPECHECK:ss)
+// Typecheck objects at evaluation time
 VAL ObjectMethodCall::evaluate() {
 	// look up the method
 	// place the result somewhere

--- a/source/TreeNode.cpp
+++ b/source/TreeNode.cpp
@@ -298,6 +298,7 @@ bool Exp::isBoolRes() {
 	if (dynamic_cast<BoolResExp *>(this)
 			|| dynamic_cast<True *>(this)
 			|| dynamic_cast<False *>(this)
+			|| dynamic_cast<Not *>(this)
 	) {
 		return true;
 	}
@@ -315,6 +316,11 @@ bool Exp::isBoolRes() {
 }
 
 bool Exp::isIntRes() {
+	// (TYPECHECK:ss)
+	// if not integer literal or intres expr or id with type int type error
+	// if ObjectMethodCall check e type
+	// if ExpObject fixme
+	// check they type of the expr within the parentheses
 	if (dynamic_cast<IntResExp *>(this)
 			|| dynamic_cast<LitInt *>(this)
 			|| dynamic_cast<Pos *>(this)

--- a/source/TreeNode.cpp
+++ b/source/TreeNode.cpp
@@ -66,7 +66,7 @@ void ClassDeclSimple::traverse() {
 
 // ClassDeclExtends //
 void ClassDeclExtends::traverse() {
-	i1->traverse();
+	i->traverse();
 	i2->traverse();
 	if (v) { v->traverse(); }
 	lowestT->reportBadMethodDecl();

--- a/source/TreeNode.cpp
+++ b/source/TreeNode.cpp
@@ -294,6 +294,53 @@ void MultipleIndices::traverse() {
 	PRINTDEBUGTREE("MultipleIndices");*/
 }
 
+bool Exp::isBoolRes() {
+	if (dynamic_cast<BoolResExp *>(this)
+			|| dynamic_cast<True *>(this)
+			|| dynamic_cast<False *>(this)
+	) {
+		return true;
+	}
+	
+	if (dynamic_cast<ExpObject *>(this) 
+			|| dynamic_cast<ObjectMethodCall *>(this) 
+			|| dynamic_cast<ArrayAccess *>(this)
+	) {
+		return true;
+	}
+	if (ParenExp * p = dynamic_cast<ParenExp *>(this)) {
+		return p->e->isBoolRes();
+	}
+	return false;
+}
+
+bool Exp::isIntRes() {
+	if (dynamic_cast<IntResExp *>(this)
+			|| dynamic_cast<LitInt *>(this)
+			|| dynamic_cast<Pos *>(this)
+			|| dynamic_cast<Neg *>(this)
+			|| dynamic_cast<Length *>(this)
+			|| dynamic_cast<ArrayAccessLength *>(this)
+	) {
+		return true;
+	}
+	//if (ObjectMethodCall * o = dynamic_cast<ObjectMethodCall *>(this)) {
+	//if (ExpObject * o = dynamic_cast<ExpObject *>(this)) {
+	if (dynamic_cast<ExpObject *>(this) 
+			|| dynamic_cast<ObjectMethodCall *>(this)
+			|| dynamic_cast<ArrayAccess *>(this)
+	) {
+		// check the return type in the obj after a table lookup
+		//return o->e->isIntRes();
+		// check the return type in the obj after a table lookup
+		//return o->e->isIntRes();
+		return true;
+	}
+	if (ParenExp * p = dynamic_cast<ParenExp *>(this)) {
+		return p->e->isIntRes();
+	}
+	return false;
+}
 // BinExp //
 
 // UnaryExp //

--- a/source/parser.y
+++ b/source/parser.y
@@ -108,7 +108,8 @@ string * typeStringHolder = nullptr;
 %%
 
 program : 
-	main_class class_decl_list { // TODO: add main + decl to table 
+ main_class class_decl_list { // TODO: add main + decl to table 
+ 		delete programRoot;
 		programRoot = new Program($1, $2);
 #ifdef ASSEM
 		rootScope = new TableNode(nullptr);
@@ -123,6 +124,7 @@ program :
 		//programRoot->traverse();
 	}
 	| main_class { 
+ 		delete programRoot;
 		programRoot = new Program($1, nullptr); 
 #ifdef ASSEM
 		rootScope = new TableNode(nullptr);
@@ -135,6 +137,8 @@ program :
 
 main_class : 
 	CLASS ID O_BR PUBLIC STATIC VOID MAIN O_PAREN STRING O_SQ C_SQ ID C_PAREN O_BR statement C_BR C_BR { 
+		programRoot = new Program(nullptr, nullptr);
+
 		$$ = new MainClass($2, $12, $15); 
 #ifdef ASSEM
 		$$->lowestT = new TableNode(nullptr);

--- a/source/parser.y
+++ b/source/parser.y
@@ -137,6 +137,7 @@ program :
 
 main_class : 
 	CLASS ID O_BR PUBLIC STATIC VOID MAIN O_PAREN STRING O_SQ C_SQ ID C_PAREN O_BR statement C_BR C_BR { 
+		// Dummy node to construct table for type checking
 		programRoot = new Program(nullptr, nullptr);
 
 		$$ = new MainClass($2, $12, $15); 

--- a/test/TypeError/loopCheck.java
+++ b/test/TypeError/loopCheck.java
@@ -15,14 +15,14 @@ class Factorial {
 		bool b;
     public int compute10(int a, int prod) {
         int prod;
-        int prod;
+        bool prod;
         int multiplier;
         int multiplier;
 				a = bool;
-				a = 1;
+				a = true;
         multiplier = 1;
         prod = 1;
-        while (multiplier <= 10) {
+        while (multiplier + 10) {
             prod = prod * multiplier;
             multiplier = multiplier + 1;
         }


### PR DESCRIPTION
* Add type checking to ast generation without using a symbol table yet
* Expand symbol for identifier type